### PR TITLE
Add student org platform backend + admin dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,33 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# ---- Backend (server/) ----
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+*.egg
+.eggs/
+build/
+
+# Virtual envs
+.venv/
+venv/
+env/
+
+# Backend environment
+server/.env
+server/.env.local
+
+# Database
+*.db
+*.sqlite
+
+# Python tooling caches
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+htmlcov/
+.coverage
+coverage.xml

--- a/dashboard/.env.example
+++ b/dashboard/.env.example
@@ -1,0 +1,6 @@
+# Frontend env (Vite exposes only VITE_-prefixed vars to the client)
+VITE_SUPABASE_URL=https://your-project.supabase.co
+VITE_SUPABASE_ANON_KEY=your-anon-key
+
+# Base URL of the FastAPI backend
+VITE_API_BASE_URL=http://localhost:8000

--- a/dashboard/.gitignore
+++ b/dashboard/.gitignore
@@ -1,0 +1,9 @@
+node_modules/
+dist/
+.env
+.env.local
+*.log
+.DS_Store
+*.tsbuildinfo
+vite.config.js
+vite.config.d.ts

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Admin Dashboard | Student Org Platform</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -1,0 +1,1510 @@
+{
+  "name": "student-org-platform-admin",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "student-org-platform-admin",
+      "version": "0.1.0",
+      "dependencies": {
+        "@supabase/supabase-js": "^2.108.2",
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7",
+        "react-router-dom": "^7.18.0"
+      },
+      "devDependencies": {
+        "@tailwindcss/vite": "^4.3.1",
+        "@types/react": "^19.2.17",
+        "@types/react-dom": "^19.2.3",
+        "@vitejs/plugin-react": "^6.0.3",
+        "tailwindcss": "^4.3.1",
+        "typescript": "^6.0.3",
+        "vite": "^8.1.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.137.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.137.0.tgz",
+      "integrity": "sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.3.tgz",
+      "integrity": "sha512-DT6Z3PhvioeHMvxo+xHc3KtqggrI7CCTXCmC2h/5zUlp5jVitv7XEy+9q5/7v8IolhlioawpMo8Kg0EEBy7J0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.3.tgz",
+      "integrity": "sha512-0NwgwsjM7LrsuVnXMK3koTpagBNOhloc/BNjKqZjv4V5zI5r13qx69uVhRx+o5Z0yy4Hzq+lpy7TAgUG/ocvrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.3.tgz",
+      "integrity": "sha512-YtiBp4disu6V560loT6PjMdiRaWmVvDNrUunAalbiFx2ggeJwxdAsgZMcoGP17uyAsTwAj5V1niksxlHnVQ1Sw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.3.tgz",
+      "integrity": "sha512-yD3EkEdXk2LypPxnf/kSZHirarsI8gcPzc62SukhR9VJTyvV+F9Q/GxWNuCojc7sXyuVC4DxRGhdDK4X8VSsbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.3.tgz",
+      "integrity": "sha512-c+8vieQbsD7HNAHKIA34w0GJ9FedFFuJGD+7E6vz7Q3uqAIugL5p45fhlsj4UaAsHpcmlqugBWMhA0/j7o0sIg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.3.tgz",
+      "integrity": "sha512-50jD0uUwLvur7Zz9LHz17kaAdTPjn5wN93hEgjvmYFRZwiR7ZJYovTd5ipyWJDAnXKvZ+wgc+/Ika6dwSF5OcA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.3.tgz",
+      "integrity": "sha512-BO9+oPL8K9poZJBfYPsXNtYjPE5uM3qeehT3aFcW4LITOl+iSqhp0abzjR2nWBUNjIZeKXjAEWBZ64WjNoHd6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.3.tgz",
+      "integrity": "sha512-f3VpLB1vQ0Eo6ecr/6cekLnvYMFF4YBFoVGkfkvPLq1bAkbAwHYQPZKoAmG6OJyTcxxoC+AvezGx/S1obNC0Mw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.3.tgz",
+      "integrity": "sha512-AmurZ26Pqx/RI9N1gzEOCklkKXl927yjfXWUUS0O7Puh8ARM/Ob8qfrD3qnWksScdw6cSrW5PSHE9DyLu7+PtA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.3.tgz",
+      "integrity": "sha512-JJpqs8bRGITDOdbkNKnlojzBabbOHrqjSvDr0IVsZObE1lBcPjxItUEY9eWIDbxaJ3cGrXPWGfGkIxFijg/URg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.3.tgz",
+      "integrity": "sha512-rSJcdjPxzA/by/6/rYs+v+bXU7UjvnbUWz8MJb6kh6+knqB1dCrtHg0uu7C/4haqJvqdkYHQ5IGn+tCH9GLW/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.3.tgz",
+      "integrity": "sha512-hQ3/PYkDJICgevvyNcVrihVeqq7k1Pp3VZ9lY+dauAYUJKO+auqApvANhvR1An9BhmqYKvW2Mu1F9u4DXSMLxQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.3.tgz",
+      "integrity": "sha512-Elcv/BtML9lXrV6JuKITc/grN2kYV9gjsQpW8Jfw4ioK0TOkjBjye0nnyqQNy9STNaI20lXNaQBRrD5gSgR0Yg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.3.tgz",
+      "integrity": "sha512-2DrEfhluH9yhiaFApmsjsjwrSYbNcY1oFTzYSP1a535jDbV98zCFanA/96TBUd0iDFcxGmw9QRExwGCXz3U+/g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.3.tgz",
+      "integrity": "sha512-OL4OMk7UPXOeVGGd3qo5zJyPIljf4AFgk5QAkPPS+OoLuOOozhuaQGC18MxVTnw/06q93gShAJzlwnSCY9YtqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.108.2",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.108.2.tgz",
+      "integrity": "sha512-tNaQmBgodDZwgB40mRwVbxFy8IDYwjdpcZ0BYrWiwlULCSQoJj4QoG4zgJT7QRPXcqipefNOzvO/qAu4dF98ag==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.108.2",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.108.2.tgz",
+      "integrity": "sha512-RNUX8EiBy3iLwAX19jtRzLyePnl11/fHcgwDHLnpKcDSXt/5qBnh3LUwAtIjT21Q66QsmNUR2esrHziLCpNubw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.4.tgz",
+      "integrity": "sha512-Gt0pqoXuIqX/8dvG0OKp/wMCobXNH3klNbUPBNyOfN0YA1IswrM3HyWFMOPk1Jy+BRaIyDPcFx4jLBwHNmlyfQ==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.108.2",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.108.2.tgz",
+      "integrity": "sha512-GQ28/Y8hk3CFmkb3kXH1h/AQx6JIYSQfO0CJMRVBcEKZoNy6C45cXAZ4fcJvRC5Id0cs6xnkUV0+c0rIocigsw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.108.2",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.108.2.tgz",
+      "integrity": "sha512-aAGxCSUemZvQIibnCdvNvgaKib28I4rfrNjKbQ9cG1uBLwUsI7hVpGXgEbypCCDhLjQlDTAiJlu7rgljYUT73g==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "^0.4.2",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.108.2",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.108.2.tgz",
+      "integrity": "sha512-TVZPQxXGxY2+A6yTtm77zUHsh70lBhYUEaJL8RQC+BghcX/ygiMG/rmXrNVBce30/WAeNPa8FiG8HbqlGeV05g==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.108.2",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.108.2.tgz",
+      "integrity": "sha512-hFhnPveb5JQg4a0QYicM0swT253YHMdfeRAl2BKHOlI5VAzuHxUGSr8RbwNLYNPauWOgQMS1H8sz8bvYlgwUfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.108.2",
+        "@supabase/functions-js": "2.108.2",
+        "@supabase/postgrest-js": "2.108.2",
+        "@supabase/realtime-js": "2.108.2",
+        "@supabase/storage-js": "2.108.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.1.tgz",
+      "integrity": "sha512-6NDaqRoAMSXD1mr/RXu0HBvNE9a2n5tHPsxu9XHLws8o4Twes5rBM2205SUUiJ9goAtadrN6xTGX0UDEwp/N4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "5.21.6",
+        "jiti": "^2.7.0",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.3.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.1.tgz",
+      "integrity": "sha512-yVPyo8RNkabVr3O2EhHEE0Rewu7YKzc1DhIqfL46LKveFrmu9XbDazNOJY7/GRuvw1h6u3utWnR29H/p5JPlgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.3.1",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.1",
+        "@tailwindcss/oxide-darwin-x64": "4.3.1",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.1",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.1",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.1",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.1",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.1",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.1",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.1",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.1",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.1.tgz",
+      "integrity": "sha512-SVlyf61g374l5cHyg8x9kf5xmLcOaxvOTsbsqDnSsDJaKOEFZ7GCvi84VAVGpxojYOs1+3K6M0UjXfqPU8vmOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.1.tgz",
+      "integrity": "sha512-hVnWLwv+e/l7c4WKyVtHVrIPvYdqWHjRB3MDIqARynzFtnQg85kmQEFCbV9Ja0VVx4xXTIiDWY60Y7iz/iNoDA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.1.tgz",
+      "integrity": "sha512-Cf7abu0WVgbhU7ANgPUnSAvm7nCvMweusHb8FnaHlLfv/Caq4GYaEZg7ZImzzmjx4lIAfuS8q+eLIS7A7IzxIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.1.tgz",
+      "integrity": "sha512-ZZqzX2Y+GXtXXfqSfpJhDm60OoZfvLHLCgm+J7NVqgHHJjG/m9ugZI77RwTsVd4fnBJuCFP6Ae6kTJb71UdS8g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.1.tgz",
+      "integrity": "sha512-/Ah/xik0LaMYfv9DZ0S/t4pBlBNYOcqtRwusjgovHkvT8ixueWCLyJjsaF5kQIckjb4IT8Q6K6p/iPmZMixYgg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.1.tgz",
+      "integrity": "sha512-gqdFoVJlw444GvpnheZLHmvTzSxI/cOUUh2KSNejQjTcYkW062SVD+En0rUgD+QV91bz1XGIGtt1HJd48xUGbQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.1.tgz",
+      "integrity": "sha512-Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.1.tgz",
+      "integrity": "sha512-Ymi8O8T15HYQdOUWUtTI6ldN0neHP85FC+Qz32xTcZ7iJXtem/x8ITev0o1e9e5rkqj4lONZfTRLvkmin1+tKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.1.tgz",
+      "integrity": "sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.1.tgz",
+      "integrity": "sha512-zsM8uOeqvVGHsAXsJxsT28ttosFahLJKCLOTUBqRAtKnVgGSRitds9T432QiT8b77Yga7JIBkulIRRlJPtYhRA==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.10.0",
+        "@emnapi/runtime": "^1.10.0",
+        "@emnapi/wasi-threads": "^1.2.1",
+        "@napi-rs/wasm-runtime": "^1.1.4",
+        "@tybys/wasm-util": "^0.10.2",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.1.tgz",
+      "integrity": "sha512-aiNvSq9BsVk8V513lDKlrCFAgf8qBMPZTpgEhInL+NwQqs97mYmupVMrPrgBBSL8Pv/0zXu9MrMF9rMun1ZeNg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.1.tgz",
+      "integrity": "sha512-xDEyu1rg290472FEGaKHnzyDyh5QH+AlWvsU5hMoMtPpzmKlRI0jaYKCgSHDYtaQWZOYbMaduSyCwFwY4n1HmA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.1.tgz",
+      "integrity": "sha512-hItDHuIIlEV61R+faXu66s1K36aTurO/Qw0e45Vskz57gXl9pWOT6eg3zmcEui6CZXddbN7zd41bwmvag4JGwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tailwindcss/node": "4.3.1",
+        "@tailwindcss/oxide": "4.3.1",
+        "tailwindcss": "4.3.1"
+      },
+      "peerDependencies": {
+        "vite": "^5.2.0 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.3.tgz",
+      "integrity": "sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.21.6",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.6.tgz",
+      "integrity": "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.7"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.0.tgz",
+      "integrity": "sha512-pTTGt8J+ji1NOmYnjzT+bAJy/1zD+Jp4ziO6cL7T3ZLvXKtusO7BpFqlRXitqpcPVqllsIXFHRMt+2/k3Xn6HQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.0.tgz",
+      "integrity": "sha512-Fi0yY6kgtKae/Th2xibdWK0KSdYZ4B53Gyf6wRtomOKWgpNm7H7+DyfDhncdz9FKbpS+1jmDhg3F4WoGJ+yFOA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.3.tgz",
+      "integrity": "sha512-1F1eEtUBtFvcGm1HQ9TiUIUHPQG7mSAODrhIzjxoUEFuo8OcbrGLiVLkevNgj84TE4lnHvnumwFjhJO5Eu135g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.137.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.3",
+        "@rolldown/binding-darwin-arm64": "1.1.3",
+        "@rolldown/binding-darwin-x64": "1.1.3",
+        "@rolldown/binding-freebsd-x64": "1.1.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.3",
+        "@rolldown/binding-linux-arm64-musl": "1.1.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.3",
+        "@rolldown/binding-linux-x64-gnu": "1.1.3",
+        "@rolldown/binding-linux-x64-musl": "1.1.3",
+        "@rolldown/binding-openharmony-arm64": "1.1.3",
+        "@rolldown/binding-wasm32-wasi": "1.1.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.3",
+        "@rolldown/binding-win32-x64-msvc": "1.1.3"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.1.tgz",
+      "integrity": "sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.0.tgz",
+      "integrity": "sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "~1.1.2",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "student-org-platform-admin",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "typecheck": "tsc -b --noEmit"
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "^2.108.2",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "react-router-dom": "^7.18.0"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "^4.3.1",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.3",
+    "tailwindcss": "^4.3.1",
+    "typescript": "^6.0.3",
+    "vite": "^8.1.0"
+  }
+}

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -1,0 +1,55 @@
+import { Navigate, Route, Routes } from "react-router-dom";
+import { useAuth } from "./auth/AuthContext";
+import Login from "./pages/Login";
+import Dashboard from "./pages/Dashboard";
+
+function FullScreen({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex h-full items-center justify-center text-slate-500">
+      {children}
+    </div>
+  );
+}
+
+export default function App() {
+  const { session, me, loading } = useAuth();
+
+  if (loading) {
+    return <FullScreen>Loading…</FullScreen>;
+  }
+
+  const isPrivileged = me?.role === "ADMIN" || me?.role === "DEV";
+
+  return (
+    <Routes>
+      <Route
+        path="/login"
+        element={
+          session && isPrivileged ? <Navigate to="/" replace /> : <Login />
+        }
+      />
+      <Route
+        path="/*"
+        element={
+          !session ? (
+            <Navigate to="/login" replace />
+          ) : !isPrivileged ? (
+            <FullScreen>
+              <div className="text-center">
+                <p className="text-lg font-medium text-slate-700">
+                  Access denied
+                </p>
+                <p className="mt-1 text-sm">
+                  Your account ({me?.role ?? "unknown"}) cannot use the admin
+                  dashboard.
+                </p>
+              </div>
+            </FullScreen>
+          ) : (
+            <Dashboard />
+          )
+        }
+      />
+    </Routes>
+  );
+}

--- a/dashboard/src/auth/AuthContext.tsx
+++ b/dashboard/src/auth/AuthContext.tsx
@@ -1,0 +1,86 @@
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from "react";
+import type { Session } from "@supabase/supabase-js";
+import { supabase } from "../lib/supabase";
+import { api } from "../lib/api";
+import type { Me } from "../lib/types";
+
+interface AuthState {
+  session: Session | null;
+  me: Me | null;
+  loading: boolean;
+  signIn: (email: string, password: string) => Promise<void>;
+  signOut: () => Promise<void>;
+}
+
+const AuthCtx = createContext<AuthState | undefined>(undefined);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [session, setSession] = useState<Session | null>(null);
+  const [me, setMe] = useState<Me | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let active = true;
+
+    async function loadProfile(s: Session | null) {
+      if (!s) {
+        setMe(null);
+        return;
+      }
+      try {
+        const profile = await api.me();
+        if (active) setMe(profile);
+      } catch {
+        if (active) setMe(null);
+      }
+    }
+
+    supabase.auth.getSession().then(async ({ data }) => {
+      if (!active) return;
+      setSession(data.session);
+      await loadProfile(data.session);
+      if (active) setLoading(false);
+    });
+
+    const { data: sub } = supabase.auth.onAuthStateChange((_e, s) => {
+      setSession(s);
+      loadProfile(s);
+    });
+
+    return () => {
+      active = false;
+      sub.subscription.unsubscribe();
+    };
+  }, []);
+
+  async function signIn(email: string, password: string) {
+    const { error } = await supabase.auth.signInWithPassword({
+      email,
+      password,
+    });
+    if (error) throw new Error(error.message);
+  }
+
+  async function signOut() {
+    await supabase.auth.signOut();
+    setMe(null);
+  }
+
+  return (
+    <AuthCtx.Provider value={{ session, me, loading, signIn, signOut }}>
+      {children}
+    </AuthCtx.Provider>
+  );
+}
+
+export function useAuth(): AuthState {
+  const ctx = useContext(AuthCtx);
+  if (!ctx) throw new Error("useAuth must be used within AuthProvider");
+  return ctx;
+}

--- a/dashboard/src/components/AuditView.tsx
+++ b/dashboard/src/components/AuditView.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useState } from "react";
+import { api } from "../lib/api";
+import type { AuditList } from "../lib/types";
+
+const ACTION_STYLE: Record<string, string> = {
+  CREATE: "bg-emerald-100 text-emerald-700",
+  DELETE: "bg-red-100 text-red-700",
+  DEACTIVATE: "bg-amber-100 text-amber-700",
+  REACTIVATE: "bg-sky-100 text-sky-700",
+};
+
+export default function AuditView() {
+  const [data, setData] = useState<AuditList | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    api
+      .audit(100, 0)
+      .then(setData)
+      .catch((e) => setError(e.message));
+  }, []);
+
+  return (
+    <div>
+      <h2 className="mb-5 text-lg font-semibold text-slate-800">Audit Log</h2>
+      {error && (
+        <p className="mb-4 rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600">
+          {error}
+        </p>
+      )}
+      <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white">
+        <table className="min-w-full divide-y divide-slate-200 text-sm">
+          <thead className="bg-slate-50">
+            <tr>
+              {["When", "Action", "Resource", "Target", "Actor", "Detail"].map(
+                (h) => (
+                  <th
+                    key={h}
+                    className="px-4 py-2 text-left font-medium text-slate-500"
+                  >
+                    {h}
+                  </th>
+                )
+              )}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-100">
+            {data?.entries.map((e) => (
+              <tr key={e.id} className="hover:bg-slate-50">
+                <td className="whitespace-nowrap px-4 py-2 text-slate-500">
+                  {new Date(e.created_at).toLocaleString()}
+                </td>
+                <td className="px-4 py-2">
+                  <span
+                    className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+                      ACTION_STYLE[e.action] ?? "bg-slate-100 text-slate-600"
+                    }`}
+                  >
+                    {e.action}
+                  </span>
+                </td>
+                <td className="px-4 py-2 text-slate-700">{e.resource}</td>
+                <td className="max-w-xs truncate px-4 py-2 text-slate-500">
+                  {e.target_id}
+                </td>
+                <td className="max-w-xs truncate px-4 py-2 text-slate-500">
+                  {e.actor_id}
+                </td>
+                <td className="px-4 py-2 text-slate-500">{e.detail ?? "—"}</td>
+              </tr>
+            ))}
+            {data && data.entries.length === 0 && (
+              <tr>
+                <td
+                  colSpan={6}
+                  className="px-4 py-8 text-center text-slate-400"
+                >
+                  No audit entries yet.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/components/CreateRowModal.tsx
+++ b/dashboard/src/components/CreateRowModal.tsx
@@ -1,0 +1,114 @@
+import { useState } from "react";
+import { api, ApiError } from "../lib/api";
+import type { ResourceInfo } from "../lib/types";
+
+export default function CreateRowModal({
+  resource,
+  onClose,
+  onCreated,
+}: {
+  resource: ResourceInfo;
+  onClose: () => void;
+  onCreated: () => void;
+}) {
+  const creatable = resource.columns.filter((c) => c.creatable);
+  const [values, setValues] = useState<Record<string, string>>({});
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  function set(name: string, value: string) {
+    setValues((v) => ({ ...v, [name]: value }));
+  }
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    setBusy(true);
+    setError(null);
+
+    // Drop empty optional fields; coerce simple booleans.
+    const payload: Record<string, unknown> = {};
+    for (const col of creatable) {
+      const raw = values[col.name];
+      if (raw === undefined || raw === "") {
+        if (col.required) {
+          setError(`"${col.name}" is required`);
+          setBusy(false);
+          return;
+        }
+        continue;
+      }
+      if (raw === "true") payload[col.name] = true;
+      else if (raw === "false") payload[col.name] = false;
+      else payload[col.name] = raw;
+    }
+
+    try {
+      await api.createRow(resource.name, payload);
+      onCreated();
+    } catch (err) {
+      setError(
+        err instanceof ApiError
+          ? err.message
+          : err instanceof Error
+            ? err.message
+            : "Failed to create"
+      );
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-10 flex items-center justify-center bg-black/40 p-4">
+      <form
+        onSubmit={submit}
+        className="w-full max-w-md rounded-xl bg-white p-6 shadow-xl"
+      >
+        <h3 className="text-lg font-semibold text-slate-800">
+          Add {resource.label} row
+        </h3>
+
+        <div className="mt-4 max-h-[60vh] space-y-3 overflow-y-auto">
+          {creatable.map((col) => (
+            <label
+              key={col.name}
+              className="block text-sm font-medium text-slate-700"
+            >
+              {col.name}
+              {col.required && <span className="text-red-500"> *</span>}
+              <input
+                value={values[col.name] ?? ""}
+                onChange={(e) => set(col.name, e.target.value)}
+                placeholder={col.required ? "required" : "optional"}
+                className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm outline-none focus:border-slate-500"
+              />
+            </label>
+          ))}
+        </div>
+
+        {error && (
+          <p className="mt-3 rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600">
+            {error}
+          </p>
+        )}
+
+        <div className="mt-6 flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-lg border border-slate-300 px-4 py-2 text-sm text-slate-600 hover:bg-slate-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={busy}
+            className="rounded-lg bg-slate-800 px-4 py-2 text-sm font-medium text-white hover:bg-slate-700 disabled:opacity-50"
+          >
+            {busy ? "Creating…" : "Create"}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/dashboard/src/components/ResourceTable.tsx
+++ b/dashboard/src/components/ResourceTable.tsx
@@ -1,0 +1,205 @@
+import { useCallback, useEffect, useState } from "react";
+import { api, ApiError } from "../lib/api";
+import type { ResourceInfo, RowList } from "../lib/types";
+import CreateRowModal from "./CreateRowModal";
+
+const PAGE = 25;
+
+function cell(value: unknown): string {
+  if (value === null || value === undefined) return "—";
+  if (typeof value === "object") return JSON.stringify(value);
+  return String(value);
+}
+
+export default function ResourceTable({ resource }: { resource: ResourceInfo }) {
+  const [data, setData] = useState<RowList | null>(null);
+  const [offset, setOffset] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [showCreate, setShowCreate] = useState(false);
+
+  const load = useCallback(async () => {
+    setError(null);
+    try {
+      const d = await api.listRows(resource.name, PAGE, offset);
+      setData(d);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load");
+    }
+  }, [resource.name, offset]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  async function act(fn: () => Promise<unknown>, confirmMsg?: string) {
+    if (confirmMsg && !window.confirm(confirmMsg)) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await fn();
+      await load();
+    } catch (e) {
+      const msg =
+        e instanceof ApiError ? e.message : e instanceof Error ? e.message : "Action failed";
+      setError(msg);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const columns = data?.rows.length
+    ? Object.keys(data.rows[0])
+    : resource.columns.map((c) => c.name);
+
+  const rowId = (row: Record<string, unknown>) => String(row["id"] ?? "");
+  const isActive = (row: Record<string, unknown>) => row["is_active"] === true;
+
+  return (
+    <div>
+      <div className="mb-5 flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-slate-800">
+            {resource.label}
+          </h2>
+          <p className="text-sm text-slate-500">
+            {data ? `${data.total} row(s)` : "Loading…"} · requires{" "}
+            {resource.min_role}
+          </p>
+        </div>
+        <button
+          onClick={() => setShowCreate(true)}
+          className="rounded-lg bg-slate-800 px-4 py-2 text-sm font-medium text-white hover:bg-slate-700"
+        >
+          + Add row
+        </button>
+      </div>
+
+      {error && (
+        <p className="mb-4 rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600">
+          {error}
+        </p>
+      )}
+
+      <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white">
+        <table className="min-w-full divide-y divide-slate-200 text-sm">
+          <thead className="bg-slate-50">
+            <tr>
+              {columns.map((c) => (
+                <th
+                  key={c}
+                  className="px-4 py-2 text-left font-medium text-slate-500"
+                >
+                  {c}
+                </th>
+              ))}
+              <th className="px-4 py-2 text-right font-medium text-slate-500">
+                Actions
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-100">
+            {data?.rows.map((row) => (
+              <tr key={rowId(row)} className="hover:bg-slate-50">
+                {columns.map((c) => (
+                  <td
+                    key={c}
+                    className="max-w-xs truncate px-4 py-2 text-slate-700"
+                    title={cell(row[c])}
+                  >
+                    {cell(row[c])}
+                  </td>
+                ))}
+                <td className="whitespace-nowrap px-4 py-2 text-right">
+                  {resource.supports_soft_delete &&
+                    (isActive(row) ? (
+                      <button
+                        disabled={busy}
+                        onClick={() =>
+                          act(() =>
+                            api.deactivateRow(resource.name, rowId(row))
+                          )
+                        }
+                        className="mr-2 text-xs font-medium text-amber-600 hover:underline disabled:opacity-50"
+                      >
+                        Deactivate
+                      </button>
+                    ) : (
+                      <button
+                        disabled={busy}
+                        onClick={() =>
+                          act(() =>
+                            api.reactivateRow(resource.name, rowId(row))
+                          )
+                        }
+                        className="mr-2 text-xs font-medium text-emerald-600 hover:underline disabled:opacity-50"
+                      >
+                        Reactivate
+                      </button>
+                    ))}
+                  <button
+                    disabled={busy}
+                    onClick={() =>
+                      act(
+                        () => api.deleteRow(resource.name, rowId(row)),
+                        `Permanently delete this ${resource.label} row? This cannot be undone.`
+                      )
+                    }
+                    className="text-xs font-medium text-red-600 hover:underline disabled:opacity-50"
+                  >
+                    Delete
+                  </button>
+                </td>
+              </tr>
+            ))}
+            {data && data.rows.length === 0 && (
+              <tr>
+                <td
+                  colSpan={columns.length + 1}
+                  className="px-4 py-8 text-center text-slate-400"
+                >
+                  No rows.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {data && data.total > PAGE && (
+        <div className="mt-4 flex items-center justify-between text-sm text-slate-500">
+          <span>
+            {offset + 1}–{Math.min(offset + PAGE, data.total)} of {data.total}
+          </span>
+          <div className="space-x-2">
+            <button
+              disabled={offset === 0}
+              onClick={() => setOffset(Math.max(0, offset - PAGE))}
+              className="rounded-lg border border-slate-300 px-3 py-1 disabled:opacity-40"
+            >
+              Prev
+            </button>
+            <button
+              disabled={offset + PAGE >= data.total}
+              onClick={() => setOffset(offset + PAGE)}
+              className="rounded-lg border border-slate-300 px-3 py-1 disabled:opacity-40"
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      )}
+
+      {showCreate && (
+        <CreateRowModal
+          resource={resource}
+          onClose={() => setShowCreate(false)}
+          onCreated={() => {
+            setShowCreate(false);
+            load();
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -1,0 +1,16 @@
+@import "tailwindcss";
+
+:root {
+  color-scheme: light;
+}
+
+html,
+body,
+#root {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+}

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -1,0 +1,96 @@
+import { supabase } from "./supabase";
+import type {
+  AuditList,
+  Me,
+  ResourceInfo,
+  RowList,
+} from "./types";
+
+const BASE = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8000";
+
+export class ApiError extends Error {
+  status: number;
+  constructor(status: number, message: string) {
+    super(message);
+    this.status = status;
+  }
+}
+
+async function authHeader(): Promise<Record<string, string>> {
+  const { data } = await supabase.auth.getSession();
+  const token = data.session?.access_token;
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+async function request<T>(
+  path: string,
+  options: RequestInit = {}
+): Promise<T> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    ...(await authHeader()),
+    ...((options.headers as Record<string, string>) ?? {}),
+  };
+
+  const resp = await fetch(`${BASE}${path}`, { ...options, headers });
+
+  if (resp.status === 204) {
+    return undefined as T;
+  }
+
+  let body: unknown = null;
+  const text = await resp.text();
+  if (text) {
+    try {
+      body = JSON.parse(text);
+    } catch {
+      body = text;
+    }
+  }
+
+  if (!resp.ok) {
+    const detail =
+      (body as { detail?: string } | null)?.detail ?? resp.statusText;
+    throw new ApiError(resp.status, detail);
+  }
+
+  return body as T;
+}
+
+export const api = {
+  me: () => request<Me>("/api/auth/me"),
+
+  resources: () =>
+    request<{ resources: ResourceInfo[] }>("/api/admin/resources").then(
+      (r) => r.resources
+    ),
+
+  listRows: (resource: string, limit = 50, offset = 0) =>
+    request<RowList>(
+      `/api/admin/${resource}?limit=${limit}&offset=${offset}`
+    ),
+
+  createRow: (resource: string, data: Record<string, unknown>) =>
+    request<{ row: Record<string, unknown> }>(`/api/admin/${resource}`, {
+      method: "POST",
+      body: JSON.stringify({ data }),
+    }),
+
+  deleteRow: (resource: string, id: string) =>
+    request<void>(`/api/admin/${resource}/${id}`, { method: "DELETE" }),
+
+  deactivateRow: (resource: string, id: string) =>
+    request<{ row: Record<string, unknown> }>(
+      `/api/admin/${resource}/${id}/deactivate`,
+      { method: "POST" }
+    ),
+
+  reactivateRow: (resource: string, id: string) =>
+    request<{ row: Record<string, unknown> }>(
+      `/api/admin/${resource}/${id}/reactivate`,
+      { method: "POST" }
+    ),
+
+  audit: (limit = 50, offset = 0) =>
+    request<AuditList>(`/api/admin/audit?limit=${limit}&offset=${offset}`),
+};

--- a/dashboard/src/lib/supabase.ts
+++ b/dashboard/src/lib/supabase.ts
@@ -1,0 +1,18 @@
+import { createClient } from "@supabase/supabase-js";
+
+const url = import.meta.env.VITE_SUPABASE_URL;
+const anonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+if (!url || !anonKey) {
+  // Surfaced early so misconfiguration is obvious in dev.
+  console.warn(
+    "Missing VITE_SUPABASE_URL or VITE_SUPABASE_ANON_KEY. Copy .env.example to .env."
+  );
+}
+
+export const supabase = createClient(url ?? "", anonKey ?? "", {
+  auth: {
+    persistSession: true,
+    autoRefreshToken: true,
+  },
+});

--- a/dashboard/src/lib/types.ts
+++ b/dashboard/src/lib/types.ts
@@ -1,0 +1,46 @@
+export type Role = "MEMBER" | "DEV" | "ADMIN";
+
+export interface Me {
+  id: string;
+  email: string;
+  first_name: string;
+  last_name: string;
+  role: Role;
+  joined_at: string;
+}
+
+export interface ResourceColumn {
+  name: string;
+  required: boolean;
+  creatable: boolean;
+}
+
+export interface ResourceInfo {
+  name: string;
+  label: string;
+  min_role: Role;
+  supports_soft_delete: boolean;
+  columns: ResourceColumn[];
+}
+
+export interface RowList {
+  rows: Record<string, unknown>[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export interface AuditEntry {
+  id: string;
+  actor_id: string;
+  action: string;
+  resource: string;
+  target_id: string;
+  detail: string | null;
+  created_at: string;
+}
+
+export interface AuditList {
+  entries: AuditEntry[];
+  total: number;
+}

--- a/dashboard/src/main.tsx
+++ b/dashboard/src/main.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
+import App from "./App";
+import { AuthProvider } from "./auth/AuthContext";
+import "./index.css";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/dashboard/src/pages/Dashboard.tsx
+++ b/dashboard/src/pages/Dashboard.tsx
@@ -1,0 +1,114 @@
+import { useEffect, useState } from "react";
+import { useAuth } from "../auth/AuthContext";
+import { api } from "../lib/api";
+import type { ResourceInfo } from "../lib/types";
+import ResourceTable from "../components/ResourceTable";
+import AuditView from "../components/AuditView";
+
+type Selection = { kind: "resource"; resource: ResourceInfo } | { kind: "audit" };
+
+export default function Dashboard() {
+  const { me, signOut } = useAuth();
+  const [resources, setResources] = useState<ResourceInfo[]>([]);
+  const [selection, setSelection] = useState<Selection | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    api
+      .resources()
+      .then((rs) => {
+        setResources(rs);
+        if (rs.length) setSelection({ kind: "resource", resource: rs[0] });
+      })
+      .catch((e) => setError(e.message));
+  }, []);
+
+  const isAdmin = me?.role === "ADMIN";
+
+  return (
+    <div className="flex h-full bg-slate-50">
+      <aside className="flex w-64 flex-col border-r border-slate-200 bg-white">
+        <div className="border-b border-slate-200 px-5 py-4">
+          <h1 className="text-sm font-semibold text-slate-800">
+            Admin Dashboard
+          </h1>
+          <p className="mt-0.5 truncate text-xs text-slate-500">
+            {me?.email}
+          </p>
+          <span className="mt-2 inline-block rounded-full bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-600">
+            {me?.role}
+          </span>
+        </div>
+
+        <nav className="flex-1 overflow-y-auto p-3">
+          <p className="px-2 pb-1 text-xs font-semibold uppercase tracking-wide text-slate-400">
+            Data
+          </p>
+          {resources.map((r) => {
+            const active =
+              selection?.kind === "resource" &&
+              selection.resource.name === r.name;
+            return (
+              <button
+                key={r.name}
+                onClick={() => setSelection({ kind: "resource", resource: r })}
+                className={`mb-1 w-full rounded-lg px-3 py-2 text-left text-sm ${
+                  active
+                    ? "bg-slate-800 text-white"
+                    : "text-slate-700 hover:bg-slate-100"
+                }`}
+              >
+                {r.label}
+              </button>
+            );
+          })}
+
+          {isAdmin && (
+            <>
+              <p className="mt-4 px-2 pb-1 text-xs font-semibold uppercase tracking-wide text-slate-400">
+                System
+              </p>
+              <button
+                onClick={() => setSelection({ kind: "audit" })}
+                className={`w-full rounded-lg px-3 py-2 text-left text-sm ${
+                  selection?.kind === "audit"
+                    ? "bg-slate-800 text-white"
+                    : "text-slate-700 hover:bg-slate-100"
+                }`}
+              >
+                Audit Log
+              </button>
+            </>
+          )}
+        </nav>
+
+        <div className="border-t border-slate-200 p-3">
+          <button
+            onClick={signOut}
+            className="w-full rounded-lg px-3 py-2 text-left text-sm text-slate-600 hover:bg-slate-100"
+          >
+            Sign out
+          </button>
+        </div>
+      </aside>
+
+      <main className="flex-1 overflow-y-auto p-8">
+        {error && (
+          <p className="mb-4 rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600">
+            {error}
+          </p>
+        )}
+        {selection?.kind === "resource" && (
+          <ResourceTable
+            key={selection.resource.name}
+            resource={selection.resource}
+          />
+        )}
+        {selection?.kind === "audit" && <AuditView />}
+        {!selection && !error && (
+          <p className="text-sm text-slate-500">No resources available.</p>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/dashboard/src/pages/Login.tsx
+++ b/dashboard/src/pages/Login.tsx
@@ -1,0 +1,73 @@
+import { useState } from "react";
+import { useAuth } from "../auth/AuthContext";
+
+export default function Login() {
+  const { signIn } = useAuth();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setBusy(true);
+    try {
+      await signIn(email, password);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Sign in failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="flex h-full items-center justify-center bg-slate-50">
+      <form
+        onSubmit={onSubmit}
+        className="w-full max-w-sm rounded-xl border border-slate-200 bg-white p-8 shadow-sm"
+      >
+        <h1 className="text-xl font-semibold text-slate-800">Admin Dashboard</h1>
+        <p className="mt-1 text-sm text-slate-500">
+          Sign in with your DEV or ADMIN account.
+        </p>
+
+        <label className="mt-6 block text-sm font-medium text-slate-700">
+          Email
+          <input
+            type="email"
+            required
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm outline-none focus:border-slate-500"
+          />
+        </label>
+
+        <label className="mt-4 block text-sm font-medium text-slate-700">
+          Password
+          <input
+            type="password"
+            required
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm outline-none focus:border-slate-500"
+          />
+        </label>
+
+        {error && (
+          <p className="mt-4 rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600">
+            {error}
+          </p>
+        )}
+
+        <button
+          type="submit"
+          disabled={busy}
+          className="mt-6 w-full rounded-lg bg-slate-800 px-4 py-2 text-sm font-medium text-white hover:bg-slate-700 disabled:opacity-50"
+        >
+          {busy ? "Signing in…" : "Sign in"}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/dashboard/src/vite-env.d.ts
+++ b/dashboard/src/vite-env.d.ts
@@ -1,0 +1,11 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_SUPABASE_URL: string;
+  readonly VITE_SUPABASE_ANON_KEY: string;
+  readonly VITE_API_BASE_URL: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/dashboard/tsconfig.json
+++ b/dashboard/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "useDefineForClassFields": true,
+    "lib": ["ES2021", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/dashboard/tsconfig.node.json
+++ b/dashboard/tsconfig.node.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true,
+    "strict": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  server: {
+    port: 5173,
+  },
+});

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,18 @@
+DATABASE_URL=postgresql+psycopg2://user:pass@host:5432/dbname
+TEST_DATABASE_URL=postgresql+psycopg2://user:pass@host:5432/test_dbname
+
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_ANON_KEY=your-anon-key
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+SUPABASE_JWT_SECRET=your-jwt-secret
+
+# Comma-separated origins allowed to call the API (admin dashboard frontend)
+CORS_ORIGINS=http://localhost:5173,http://127.0.0.1:5173
+
+# Used only in tests — a local secret, never the real SUPABASE_JWT_SECRET
+TEST_JWT_SECRET=test-jwt-secret-for-tests-only
+
+# Notion (used by notion/ module, not auth)
+NOTION_API_KEY=your-notion-api-key
+NOTION_RESUME_COMPONENTS_DB_ID=your-db-id
+NOTION_APPLICATIONS_DB_ID=your-db-id

--- a/server/alembic.ini
+++ b/server/alembic.ini
@@ -1,0 +1,43 @@
+[alembic]
+script_location = alembic
+prepend_sys_path = .
+version_path_separator = os
+
+# DATABASE_URL is read from the environment in alembic/env.py
+sqlalchemy.url =
+
+[post_write_hooks]
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/server/alembic/env.py
+++ b/server/alembic/env.py
@@ -1,0 +1,52 @@
+import os
+from logging.config import fileConfig
+
+from sqlalchemy import engine_from_config, pool
+from alembic import context
+from dotenv import load_dotenv
+
+load_dotenv()
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# Import all models so Alembic can detect them
+from app.admin.models import AdminAuditLog  # noqa: F401
+from app.users.models import User, RoleHistory  # noqa: F401
+from sqlmodel import SQLModel
+
+target_metadata = SQLModel.metadata
+
+config.set_main_option("sqlalchemy.url", os.environ["DATABASE_URL"])
+
+
+def run_migrations_offline() -> None:
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/server/alembic/script.py.mako
+++ b/server/alembic/script.py.mako
@@ -1,0 +1,26 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/server/alembic/versions/001_initial_auth.py
+++ b/server/alembic/versions/001_initial_auth.py
@@ -1,0 +1,72 @@
+"""initial auth tables
+
+Revision ID: 001
+Revises:
+Create Date: 2026-05-21
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "001"
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    role_enum = sa.Enum("MEMBER", "DEV", "ADMIN", name="role")
+    role_enum.create(op.get_bind(), checkfirst=True)
+
+    op.create_table(
+        "users",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("supabase_id", sa.String(), nullable=False),
+        sa.Column("email", sa.String(), nullable=False),
+        sa.Column("first_name", sa.String(), nullable=False),
+        sa.Column("last_name", sa.String(), nullable=False),
+        sa.Column(
+            "role",
+            sa.Enum("MEMBER", "DEV", "ADMIN", name="role", create_type=False),
+            nullable=False,
+            server_default="MEMBER",
+        ),
+        sa.Column("discord_id", sa.String(), nullable=True),
+        sa.Column("joined_at", sa.DateTime(), nullable=False),
+        sa.Column("last_login", sa.DateTime(), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default="true"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("supabase_id"),
+        sa.UniqueConstraint("email"),
+        sa.UniqueConstraint("discord_id"),
+    )
+    op.create_index("ix_users_supabase_id", "users", ["supabase_id"])
+
+    op.create_table(
+        "role_history",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("user_id", sa.UUID(), nullable=False),
+        sa.Column(
+            "old_role",
+            sa.Enum("MEMBER", "DEV", "ADMIN", name="role", create_type=False),
+            nullable=True,
+        ),
+        sa.Column(
+            "new_role",
+            sa.Enum("MEMBER", "DEV", "ADMIN", name="role", create_type=False),
+            nullable=False,
+        ),
+        sa.Column("changed_by", sa.UUID(), nullable=True),
+        sa.Column("changed_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.ForeignKeyConstraint(["changed_by"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("role_history")
+    op.drop_table("users")
+    sa.Enum(name="role").drop(op.get_bind(), checkfirst=True)

--- a/server/alembic/versions/002_admin_audit_log.py
+++ b/server/alembic/versions/002_admin_audit_log.py
@@ -1,0 +1,52 @@
+"""admin audit log
+
+Revision ID: 002
+Revises: 001
+Create Date: 2026-06-28
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "002"
+down_revision: Union[str, None] = "001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    action_enum = sa.Enum(
+        "CREATE", "DELETE", "DEACTIVATE", "REACTIVATE", name="admin_action"
+    )
+    action_enum.create(op.get_bind(), checkfirst=True)
+
+    op.create_table(
+        "admin_audit_log",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("actor_id", sa.UUID(), nullable=False),
+        sa.Column(
+            "action",
+            sa.Enum(
+                "CREATE",
+                "DELETE",
+                "DEACTIVATE",
+                "REACTIVATE",
+                name="admin_action",
+                create_type=False,
+            ),
+            nullable=False,
+        ),
+        sa.Column("resource", sa.String(), nullable=False),
+        sa.Column("target_id", sa.String(), nullable=False),
+        sa.Column("detail", sa.String(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["actor_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("admin_audit_log")
+    sa.Enum(name="admin_action").drop(op.get_bind(), checkfirst=True)

--- a/server/app/_template/models.py
+++ b/server/app/_template/models.py
@@ -1,0 +1,36 @@
+"""
+TEMPLATE: models.py
+===================
+Define SQLModel table classes here. One file per feature.
+
+Rules:
+- Use SQLModel with `table=True` for database tables
+- Use `Field(foreign_key="table.col")` for FK relationships
+- Models live here; request/response schemas go in schemas.py
+- Never import from other feature folders — only from app.users.models for shared types
+
+Copy this file to your feature folder and rename the class.
+"""
+import uuid
+from datetime import UTC, datetime
+from typing import Optional
+
+from sqlmodel import Field, SQLModel
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC).replace(tzinfo=None)
+
+
+# Example: a simple table linked to a user
+class AttendanceRecord(SQLModel, table=True):
+    __tablename__ = "attendance_records"
+
+    id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
+
+    # FK to the shared users table — always reference users.id, never supabase_id
+    user_id: uuid.UUID = Field(foreign_key="users.id", nullable=False)
+
+    event_name: str
+    attended_at: datetime = Field(default_factory=_utcnow)
+    notes: Optional[str] = Field(default=None)

--- a/server/app/_template/router.py
+++ b/server/app/_template/router.py
@@ -1,0 +1,51 @@
+"""
+TEMPLATE: router.py
+===================
+Thin routing layer. Routes only: validate input, call service, return schema.
+No business logic here — that lives in service.py.
+
+Rules:
+- Import get_current_user for any route that requires authentication
+- Import require_role for routes restricted to specific roles
+- require_role must be wrapped in Depends(): `Depends(require_role(Role.ADMIN))`
+- Register this router in server/app/main.py:
+      from app.<feature>.router import router as <feature>_router
+      app.include_router(<feature>_router, prefix="/api/<feature>", tags=["<feature>"])
+
+Copy this file to your feature folder and rename the prefix in main.py.
+"""
+import uuid
+
+from fastapi import APIRouter, Depends, status
+from sqlmodel import Session
+
+from app._template import service
+from app._template.schemas import AttendanceCreateRequest, AttendanceResponse
+from app.auth.dependencies import get_current_user, require_role
+from app.database import get_session
+from app.users.models import Role, User
+
+router = APIRouter()
+
+
+# Any authenticated user can log attendance for themselves
+@router.post(
+    "/", response_model=AttendanceResponse, status_code=status.HTTP_201_CREATED
+)
+def create_attendance(
+    req: AttendanceCreateRequest,
+    user: User = Depends(get_current_user),
+    session: Session = Depends(get_session),
+) -> AttendanceResponse:
+    record = service.create_attendance(req, user, session)
+    return AttendanceResponse.model_validate(record)
+
+
+# DEV or ADMIN can fetch any record by ID
+@router.get("/{record_id}", response_model=AttendanceResponse)
+def get_attendance(
+    record_id: uuid.UUID,
+    user: User = Depends(require_role(Role.DEV, Role.ADMIN)),
+    session: Session = Depends(get_session),
+) -> AttendanceResponse:
+    return service.get_attendance(record_id, user, session)

--- a/server/app/_template/schemas.py
+++ b/server/app/_template/schemas.py
@@ -1,0 +1,36 @@
+"""
+TEMPLATE: schemas.py
+====================
+Pydantic request/response models. These are NOT database tables.
+
+Rules:
+- Use BaseModel (not SQLModel) for schemas
+- Keep request and response schemas separate — never reuse a request schema
+  as a response
+- Add `model_config = {"from_attributes": True}` on response schemas so
+  `Model.model_validate(orm_obj)` works
+- Import Role from app.users.models if you need to expose the user's role
+
+Copy this file to your feature folder and rename the classes.
+"""
+import uuid
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class AttendanceCreateRequest(BaseModel):
+    event_name: str
+    notes: Optional[str] = None
+
+
+class AttendanceResponse(BaseModel):
+    id: uuid.UUID
+    user_id: uuid.UUID
+    event_name: str
+    attended_at: datetime
+    notes: Optional[str]
+
+    # Required to use .model_validate(orm_object)
+    model_config = {"from_attributes": True}

--- a/server/app/_template/service.py
+++ b/server/app/_template/service.py
@@ -1,0 +1,50 @@
+"""
+TEMPLATE: service.py
+====================
+Business logic lives here. Routers call service functions; services call the DB.
+
+Rules:
+- Service functions take explicit arguments (request schema + session) — no FastAPI
+  dependencies inside service functions. get_current_user belongs in the router.
+- Raise HTTPException from the service layer (not the router) so error handling
+  stays in one place
+- Always commit at the end of a write operation; rollback in the except block
+
+Copy this file to your feature folder and rename the functions.
+"""
+from fastapi import HTTPException
+from sqlmodel import Session, select
+
+from app._template.models import AttendanceRecord
+from app._template.schemas import AttendanceCreateRequest, AttendanceResponse
+from app.users.models import User
+
+
+def create_attendance(
+    req: AttendanceCreateRequest, user: User, session: Session
+) -> AttendanceRecord:
+    record = AttendanceRecord(
+        user_id=user.id,
+        event_name=req.event_name,
+        notes=req.notes,
+    )
+    try:
+        session.add(record)
+        session.commit()
+        session.refresh(record)
+    except Exception as exc:
+        session.rollback()
+        raise HTTPException(status_code=500, detail="Failed to save record") from exc
+    return record
+
+
+def get_attendance(record_id, user: User, session: Session) -> AttendanceResponse:
+    record = session.exec(
+        select(AttendanceRecord).where(
+            AttendanceRecord.id == record_id,
+            AttendanceRecord.user_id == user.id,
+        )
+    ).first()
+    if not record:
+        raise HTTPException(status_code=404, detail="Record not found")
+    return AttendanceResponse.model_validate(record)

--- a/server/app/admin/models.py
+++ b/server/app/admin/models.py
@@ -1,0 +1,35 @@
+import enum
+import uuid
+from datetime import UTC, datetime
+from typing import Optional
+
+from sqlalchemy import Enum as SAEnum
+from sqlmodel import Column, Field, SQLModel
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC).replace(tzinfo=None)
+
+
+class AdminAction(str, enum.Enum):
+    CREATE = "CREATE"
+    DELETE = "DELETE"
+    DEACTIVATE = "DEACTIVATE"
+    REACTIVATE = "REACTIVATE"
+
+
+class AdminAuditLog(SQLModel, table=True):
+    __tablename__ = "admin_audit_log"
+
+    id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
+    actor_id: uuid.UUID = Field(foreign_key="users.id", nullable=False)
+    action: AdminAction = Field(
+        sa_column=Column(
+            SAEnum(AdminAction, name="admin_action", native_enum=True),
+            nullable=False,
+        )
+    )
+    resource: str = Field(nullable=False)
+    target_id: str = Field(nullable=False)
+    detail: Optional[str] = Field(default=None)
+    created_at: datetime = Field(default_factory=_utcnow)

--- a/server/app/admin/registry.py
+++ b/server/app/admin/registry.py
@@ -1,0 +1,90 @@
+"""Registry of admin-manageable resources.
+
+This is the one place that knows about every table the admin dashboard can
+manage. Adding a new feature table to the dashboard = add one entry here.
+
+The admin feature is intentionally allowed to import other features' models —
+it is a cross-cutting management layer, not a normal feature. Normal features
+must still follow the "no cross-feature imports" rule.
+"""
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Optional
+
+from sqlmodel import SQLModel
+
+from app.users.models import Role, RoleHistory, User
+
+
+@dataclass(frozen=True)
+class ResourceConfig:
+    name: str
+    label: str
+    model: type[SQLModel]
+    min_role: Role
+    # Column name used for soft-delete (e.g. "is_active"). None = no soft delete.
+    soft_delete_field: Optional[str] = None
+    # Fields the frontend must never send on create (server-managed).
+    create_exclude: frozenset[str] = field(default_factory=frozenset)
+    # Special delete handler name resolved in the service layer (e.g. "user").
+    special_delete: Optional[str] = None
+
+
+REGISTRY: dict[str, ResourceConfig] = {
+    "users": ResourceConfig(
+        name="users",
+        label="Users",
+        model=User,
+        min_role=Role.ADMIN,
+        soft_delete_field="is_active",
+        create_exclude=frozenset({"id", "joined_at", "last_login"}),
+        special_delete="user",
+    ),
+    "role_history": ResourceConfig(
+        name="role_history",
+        label="Role History",
+        model=RoleHistory,
+        min_role=Role.ADMIN,
+        create_exclude=frozenset({"id", "changed_at"}),
+    ),
+    # Future feature tables go here, e.g.:
+    # "attendance": ResourceConfig(
+    #     name="attendance",
+    #     label="Attendance",
+    #     model=AttendanceRecord,
+    #     min_role=Role.DEV,
+    # ),
+}
+
+
+def get_resource(name: str) -> Optional[ResourceConfig]:
+    return REGISTRY.get(name)
+
+
+def visible_resources(role: Role) -> list[ResourceConfig]:
+    """Resources a given role is allowed to manage."""
+    order = {Role.MEMBER: 0, Role.DEV: 1, Role.ADMIN: 2}
+    return [r for r in REGISTRY.values() if order[role] >= order[r.min_role]]
+
+
+def can_access(role: Role, cfg: ResourceConfig) -> bool:
+    order = {Role.MEMBER: 0, Role.DEV: 1, Role.ADMIN: 2}
+    return order[role] >= order[cfg.min_role]
+
+
+def column_metadata(cfg: ResourceConfig) -> list[dict]:
+    """Lightweight column descriptors for the frontend table/form."""
+    cols: list[dict] = []
+    for fname, finfo in cfg.model.model_fields.items():
+        cols.append(
+            {
+                "name": fname,
+                "required": finfo.is_required(),
+                "creatable": fname not in cfg.create_exclude,
+            }
+        )
+    return cols
+
+
+# Used by service.py to keep a stable accessor without exposing the dataclass.
+DeleteHandler = Callable[..., None]

--- a/server/app/admin/router.py
+++ b/server/app/admin/router.py
@@ -1,0 +1,86 @@
+from fastapi import APIRouter, Depends, status
+from sqlmodel import Session
+
+from app.admin import service
+from app.admin.schemas import (
+    AuditLogResponse,
+    CreateRowRequest,
+    ResourceListResponse,
+    RowListResponse,
+    RowResponse,
+)
+from app.auth.dependencies import require_role
+from app.database import get_session
+from app.users.models import Role, User
+
+router = APIRouter()
+
+
+@router.get("/resources", response_model=ResourceListResponse)
+def list_resources(
+    user: User = Depends(require_role(Role.DEV, Role.ADMIN)),
+) -> ResourceListResponse:
+    return service.list_resources(user)
+
+
+@router.get("/audit", response_model=AuditLogResponse)
+def list_audit(
+    limit: int = 50,
+    offset: int = 0,
+    user: User = Depends(require_role(Role.ADMIN)),
+    session: Session = Depends(get_session),
+) -> AuditLogResponse:
+    return service.list_audit(user, session, limit, offset)
+
+
+@router.get("/{resource}", response_model=RowListResponse)
+def list_rows(
+    resource: str,
+    limit: int = 50,
+    offset: int = 0,
+    user: User = Depends(require_role(Role.DEV, Role.ADMIN)),
+    session: Session = Depends(get_session),
+) -> RowListResponse:
+    return service.list_rows(resource, user, session, limit, offset)
+
+
+@router.post(
+    "/{resource}", response_model=RowResponse, status_code=status.HTTP_201_CREATED
+)
+def create_row(
+    resource: str,
+    req: CreateRowRequest,
+    user: User = Depends(require_role(Role.DEV, Role.ADMIN)),
+    session: Session = Depends(get_session),
+) -> RowResponse:
+    return service.create_row(resource, req.data, user, session)
+
+
+@router.delete("/{resource}/{row_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_row(
+    resource: str,
+    row_id: str,
+    user: User = Depends(require_role(Role.DEV, Role.ADMIN)),
+    session: Session = Depends(get_session),
+) -> None:
+    service.delete_row(resource, row_id, user, session)
+
+
+@router.post("/{resource}/{row_id}/deactivate", response_model=RowResponse)
+def deactivate_row(
+    resource: str,
+    row_id: str,
+    user: User = Depends(require_role(Role.DEV, Role.ADMIN)),
+    session: Session = Depends(get_session),
+) -> RowResponse:
+    return service.set_active(resource, row_id, False, user, session)
+
+
+@router.post("/{resource}/{row_id}/reactivate", response_model=RowResponse)
+def reactivate_row(
+    resource: str,
+    row_id: str,
+    user: User = Depends(require_role(Role.DEV, Role.ADMIN)),
+    session: Session = Depends(get_session),
+) -> RowResponse:
+    return service.set_active(resource, row_id, True, user, session)

--- a/server/app/admin/schemas.py
+++ b/server/app/admin/schemas.py
@@ -1,0 +1,56 @@
+from datetime import datetime
+from typing import Any, Optional
+
+from pydantic import BaseModel
+
+from app.users.models import Role
+
+
+class ResourceColumn(BaseModel):
+    name: str
+    required: bool
+    creatable: bool
+
+
+class ResourceInfo(BaseModel):
+    name: str
+    label: str
+    min_role: Role
+    supports_soft_delete: bool
+    columns: list[ResourceColumn]
+
+
+class ResourceListResponse(BaseModel):
+    resources: list[ResourceInfo]
+
+
+class RowListResponse(BaseModel):
+    rows: list[dict[str, Any]]
+    total: int
+    limit: int
+    offset: int
+
+
+class CreateRowRequest(BaseModel):
+    data: dict[str, Any]
+
+
+class RowResponse(BaseModel):
+    row: dict[str, Any]
+
+
+class AuditLogEntry(BaseModel):
+    id: Any
+    actor_id: Any
+    action: str
+    resource: str
+    target_id: str
+    detail: Optional[str]
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class AuditLogResponse(BaseModel):
+    entries: list[AuditLogEntry]
+    total: int

--- a/server/app/admin/service.py
+++ b/server/app/admin/service.py
@@ -1,0 +1,246 @@
+import logging
+import uuid
+from typing import Any
+
+from fastapi import HTTPException
+from sqlmodel import Session, func, select
+
+from app.admin.models import AdminAction, AdminAuditLog
+from app.admin.registry import (
+    ResourceConfig,
+    can_access,
+    column_metadata,
+    get_resource,
+    visible_resources,
+)
+from app.admin.schemas import (
+    AuditLogResponse,
+    ResourceColumn,
+    ResourceInfo,
+    ResourceListResponse,
+    RowListResponse,
+    RowResponse,
+)
+from app.auth.supabase_client import get_supabase_admin
+from app.users.models import Role, RoleHistory, User
+
+logger = logging.getLogger(__name__)
+
+
+def _serialize(obj: Any) -> dict[str, Any]:
+    return obj.model_dump(mode="json")
+
+
+def _resolve_resource(name: str, user: User) -> ResourceConfig:
+    cfg = get_resource(name)
+    if cfg is None:
+        raise HTTPException(status_code=404, detail="Unknown resource")
+    if not can_access(user.role, cfg):
+        raise HTTPException(status_code=403, detail="Insufficient permissions")
+    return cfg
+
+
+def _parse_pk(row_id: str) -> Any:
+    try:
+        return uuid.UUID(row_id)
+    except ValueError:
+        return row_id
+
+
+def _get_row(cfg: ResourceConfig, row_id: str, session: Session) -> Any:
+    obj = session.get(cfg.model, _parse_pk(row_id))
+    if obj is None:
+        raise HTTPException(status_code=404, detail="Row not found")
+    return obj
+
+
+def _audit(
+    session: Session,
+    actor: User,
+    action: AdminAction,
+    resource: str,
+    target_id: str,
+    detail: str | None = None,
+) -> None:
+    session.add(
+        AdminAuditLog(
+            actor_id=actor.id,
+            action=action,
+            resource=resource,
+            target_id=str(target_id),
+            detail=detail,
+        )
+    )
+
+
+def list_resources(user: User) -> ResourceListResponse:
+    infos = [
+        ResourceInfo(
+            name=cfg.name,
+            label=cfg.label,
+            min_role=cfg.min_role,
+            supports_soft_delete=cfg.soft_delete_field is not None,
+            columns=[ResourceColumn(**c) for c in column_metadata(cfg)],
+        )
+        for cfg in visible_resources(user.role)
+    ]
+    return ResourceListResponse(resources=infos)
+
+
+def list_rows(
+    resource: str, user: User, session: Session, limit: int, offset: int
+) -> RowListResponse:
+    cfg = _resolve_resource(resource, user)
+    total = session.exec(select(func.count()).select_from(cfg.model)).one()
+    rows = session.exec(select(cfg.model).offset(offset).limit(limit)).all()
+    return RowListResponse(
+        rows=[_serialize(r) for r in rows],
+        total=int(total),
+        limit=limit,
+        offset=offset,
+    )
+
+
+def create_row(
+    resource: str, data: dict[str, Any], user: User, session: Session
+) -> RowResponse:
+    cfg = _resolve_resource(resource, user)
+
+    allowed = {
+        k: v
+        for k, v in data.items()
+        if k in cfg.model.model_fields and k not in cfg.create_exclude
+    }
+    try:
+        obj = cfg.model(**allowed)
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail="Invalid row data") from exc
+
+    try:
+        session.add(obj)
+        session.flush()
+        _audit(session, user, AdminAction.CREATE, resource, getattr(obj, "id", ""))
+        session.commit()
+        session.refresh(obj)
+    except Exception as exc:
+        session.rollback()
+        raise HTTPException(status_code=400, detail="Failed to create row") from exc
+
+    return RowResponse(row=_serialize(obj))
+
+
+def delete_row(resource: str, row_id: str, user: User, session: Session) -> None:
+    cfg = _resolve_resource(resource, user)
+
+    if cfg.special_delete == "user":
+        _delete_user(row_id, user, session)
+        return
+
+    obj = _get_row(cfg, row_id, session)
+    try:
+        session.delete(obj)
+        _audit(session, user, AdminAction.DELETE, resource, row_id)
+        session.commit()
+    except Exception as exc:
+        session.rollback()
+        raise HTTPException(status_code=400, detail="Failed to delete row") from exc
+
+
+def _delete_user(row_id: str, actor: User, session: Session) -> None:
+    target = session.get(User, _parse_pk(row_id))
+    if target is None:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    _guard_user_mutation(target, actor, session)
+
+    supabase_id = target.supabase_id
+    try:
+        # Detach role history: rows authored by this user lose their author,
+        # rows about this user are removed.
+        authored = session.exec(
+            select(RoleHistory).where(RoleHistory.changed_by == target.id)
+        ).all()
+        for h in authored:
+            h.changed_by = None
+            session.add(h)
+
+        about = session.exec(
+            select(RoleHistory).where(RoleHistory.user_id == target.id)
+        ).all()
+        for h in about:
+            session.delete(h)
+
+        session.delete(target)
+        _audit(session, actor, AdminAction.DELETE, "users", row_id)
+        session.commit()
+    except Exception as exc:
+        session.rollback()
+        raise HTTPException(status_code=400, detail="Failed to delete user") from exc
+
+    try:
+        get_supabase_admin().auth.admin.delete_user(supabase_id)
+    except Exception:
+        logger.error("Orphaned Supabase auth user after delete: %s", supabase_id)
+
+
+def _guard_user_mutation(target: User, actor: User, session: Session) -> None:
+    if target.id == actor.id:
+        raise HTTPException(
+            status_code=400, detail="You cannot delete or deactivate yourself"
+        )
+    # Only a problem if we are about to remove the last *active* admin.
+    if target.role == Role.ADMIN and target.is_active:
+        active_admins = session.exec(
+            select(func.count())
+            .select_from(User)
+            .where(User.role == Role.ADMIN, User.is_active == True)  # noqa: E712
+        ).one()
+        if int(active_admins) <= 1:
+            raise HTTPException(
+                status_code=400, detail="Cannot remove the last active admin"
+            )
+
+
+def set_active(
+    resource: str, row_id: str, active: bool, user: User, session: Session
+) -> RowResponse:
+    cfg = _resolve_resource(resource, user)
+    if cfg.soft_delete_field is None:
+        raise HTTPException(
+            status_code=400, detail="Resource does not support soft delete"
+        )
+
+    obj = _get_row(cfg, row_id, session)
+
+    if cfg.special_delete == "user" and not active:
+        _guard_user_mutation(obj, user, session)
+
+    try:
+        setattr(obj, cfg.soft_delete_field, active)
+        session.add(obj)
+        action = AdminAction.REACTIVATE if active else AdminAction.DEACTIVATE
+        _audit(session, user, action, resource, row_id)
+        session.commit()
+        session.refresh(obj)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        session.rollback()
+        raise HTTPException(status_code=400, detail="Failed to update row") from exc
+
+    return RowResponse(row=_serialize(obj))
+
+
+def list_audit(
+    user: User, session: Session, limit: int, offset: int
+) -> AuditLogResponse:
+    if user.role != Role.ADMIN:
+        raise HTTPException(status_code=403, detail="Insufficient permissions")
+    total = session.exec(select(func.count()).select_from(AdminAuditLog)).one()
+    entries = session.exec(
+        select(AdminAuditLog)
+        .order_by(AdminAuditLog.created_at.desc())  # type: ignore[attr-defined]
+        .offset(offset)
+        .limit(limit)
+    ).all()
+    return AuditLogResponse(entries=entries, total=int(total))  # type: ignore[arg-type]

--- a/server/app/auth/dependencies.py
+++ b/server/app/auth/dependencies.py
@@ -1,0 +1,49 @@
+import os
+from collections.abc import Callable
+
+import jwt
+from fastapi import Depends, HTTPException
+from fastapi.security import OAuth2PasswordBearer
+from sqlmodel import Session, select
+
+from app.database import get_session
+from app.users.models import Role, User
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/auth/login")
+
+
+def _decode_token(token: str) -> dict:
+    try:
+        return jwt.decode(
+            token,
+            os.environ["SUPABASE_JWT_SECRET"],
+            algorithms=["HS256"],
+            audience="authenticated",
+        )
+    except jwt.ExpiredSignatureError:
+        raise HTTPException(status_code=401, detail="Token expired")
+    except jwt.InvalidTokenError:
+        raise HTTPException(status_code=401, detail="Invalid token")
+
+
+def get_current_user(
+    token: str = Depends(oauth2_scheme),
+    session: Session = Depends(get_session),
+) -> User:
+    payload = _decode_token(token)
+    supabase_id: str | None = payload.get("sub")
+    if not supabase_id:
+        raise HTTPException(status_code=401, detail="Invalid token")
+    user = session.exec(select(User).where(User.supabase_id == supabase_id)).first()
+    if not user:
+        raise HTTPException(status_code=401, detail="User not found")
+    return user
+
+
+def require_role(*roles: Role) -> Callable:
+    def dependency(user: User = Depends(get_current_user)) -> User:
+        if user.role not in roles:
+            raise HTTPException(status_code=403, detail="Insufficient permissions")
+        return user
+
+    return dependency

--- a/server/app/auth/router.py
+++ b/server/app/auth/router.py
@@ -1,0 +1,32 @@
+from fastapi import APIRouter, Depends, status
+from sqlmodel import Session
+
+from app.auth import service
+from app.auth.dependencies import get_current_user
+from app.auth.schemas import (
+    LoginRequest,
+    LoginResponse,
+    SignupRequest,
+    UserResponse,
+)
+from app.database import get_session
+from app.users.models import User
+
+router = APIRouter()
+
+
+@router.post(
+    "/signup", response_model=UserResponse, status_code=status.HTTP_201_CREATED
+)
+def signup(req: SignupRequest, session: Session = Depends(get_session)) -> User:
+    return service.signup(req, session)
+
+
+@router.post("/login", response_model=LoginResponse)
+def login(req: LoginRequest, session: Session = Depends(get_session)) -> LoginResponse:
+    return service.login(req, session)
+
+
+@router.get("/me", response_model=UserResponse)
+def me(user: User = Depends(get_current_user)) -> UserResponse:
+    return service.get_me(user)

--- a/server/app/auth/schemas.py
+++ b/server/app/auth/schemas.py
@@ -1,0 +1,34 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, EmailStr
+
+from app.users.models import Role
+
+
+class SignupRequest(BaseModel):
+    email: EmailStr
+    password: str
+    first_name: str
+    last_name: str
+
+
+class LoginRequest(BaseModel):
+    email: EmailStr
+    password: str
+
+
+class LoginResponse(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+
+
+class UserResponse(BaseModel):
+    id: uuid.UUID
+    email: str
+    first_name: str
+    last_name: str
+    role: Role
+    joined_at: datetime
+
+    model_config = {"from_attributes": True}

--- a/server/app/auth/service.py
+++ b/server/app/auth/service.py
@@ -1,0 +1,79 @@
+import logging
+from datetime import UTC, datetime
+
+from fastapi import HTTPException
+from sqlmodel import Session, select
+
+from app.auth.schemas import LoginRequest, LoginResponse, SignupRequest, UserResponse
+from app.auth.supabase_client import get_supabase, get_supabase_admin
+from app.users.models import Role, RoleHistory, User
+
+logger = logging.getLogger(__name__)
+
+
+def signup(req: SignupRequest, session: Session) -> User:
+    sb = get_supabase()
+    try:
+        auth_resp = sb.auth.sign_up({"email": req.email, "password": req.password})
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail="Signup failed") from exc
+
+    if not auth_resp.user:
+        raise HTTPException(status_code=400, detail="Signup failed")
+
+    supabase_user_id = str(auth_resp.user.id)
+
+    user = User(
+        supabase_id=supabase_user_id,
+        email=req.email,
+        first_name=req.first_name,
+        last_name=req.last_name,
+        role=Role.MEMBER,
+    )
+    try:
+        session.add(user)
+        session.flush()
+
+        history = RoleHistory(
+            user_id=user.id,
+            old_role=None,
+            new_role=Role.MEMBER,
+            changed_by=None,
+        )
+        session.add(history)
+        session.commit()
+        session.refresh(user)
+    except Exception as exc:
+        session.rollback()
+        try:
+            get_supabase_admin().auth.admin.delete_user(supabase_user_id)
+        except Exception:
+            logger.error("Orphaned Supabase auth user: %s", supabase_user_id)
+        raise HTTPException(status_code=500, detail="Failed to create user") from exc
+
+    return user
+
+
+def login(req: LoginRequest, session: Session) -> LoginResponse:
+    sb = get_supabase()
+    try:
+        auth_resp = sb.auth.sign_in_with_password(
+            {"email": req.email, "password": req.password}
+        )
+    except Exception as exc:
+        raise HTTPException(status_code=401, detail="Invalid credentials") from exc
+
+    if not auth_resp.session:
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+
+    user = session.exec(select(User).where(User.email == req.email)).first()
+    if user:
+        user.last_login = datetime.now(UTC).replace(tzinfo=None)  # naive UTC
+        session.add(user)
+        session.commit()
+
+    return LoginResponse(access_token=auth_resp.session.access_token)
+
+
+def get_me(user: User) -> UserResponse:
+    return UserResponse.model_validate(user)

--- a/server/app/auth/supabase_client.py
+++ b/server/app/auth/supabase_client.py
@@ -1,0 +1,13 @@
+import os
+
+from supabase import Client, create_client
+
+
+def get_supabase() -> Client:
+    return create_client(os.environ["SUPABASE_URL"], os.environ["SUPABASE_ANON_KEY"])
+
+
+def get_supabase_admin() -> Client:
+    return create_client(
+        os.environ["SUPABASE_URL"], os.environ["SUPABASE_SERVICE_ROLE_KEY"]
+    )

--- a/server/app/database.py
+++ b/server/app/database.py
@@ -1,0 +1,19 @@
+import os
+from collections.abc import Generator
+
+from dotenv import load_dotenv
+from sqlmodel import Session, SQLModel, create_engine
+
+load_dotenv()
+
+DATABASE_URL = os.environ["DATABASE_URL"]
+engine = create_engine(DATABASE_URL)
+
+
+def create_db_and_tables() -> None:
+    SQLModel.metadata.create_all(engine)
+
+
+def get_session() -> Generator[Session, None, None]:
+    with Session(engine) as session:
+        yield session

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -1,0 +1,23 @@
+import os
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from app.admin.router import router as admin_router
+from app.auth.router import router as auth_router
+
+app = FastAPI(title="Student Org Platform")
+
+_origins = os.environ.get(
+    "CORS_ORIGINS", "http://localhost:5173,http://127.0.0.1:5173"
+).split(",")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[o.strip() for o in _origins if o.strip()],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+app.include_router(auth_router, prefix="/api/auth", tags=["auth"])
+app.include_router(admin_router, prefix="/api/admin", tags=["admin"])

--- a/server/app/users/models.py
+++ b/server/app/users/models.py
@@ -1,0 +1,61 @@
+import enum
+import uuid
+from datetime import UTC, datetime
+from typing import Optional
+
+from sqlalchemy import Enum as SAEnum
+from sqlmodel import Column, Field, SQLModel
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC).replace(tzinfo=None)
+
+
+class Role(str, enum.Enum):
+    MEMBER = "MEMBER"
+    DEV = "DEV"
+    ADMIN = "ADMIN"
+
+
+class User(SQLModel, table=True):
+    __tablename__ = "users"
+
+    id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
+    supabase_id: str = Field(unique=True, nullable=False, index=True)
+    email: str = Field(unique=True, nullable=False)
+    first_name: str
+    last_name: str
+    role: Role = Field(
+        default=Role.MEMBER,
+        sa_column=Column(
+            SAEnum(Role, name="role", native_enum=True), nullable=False
+        ),
+    )
+    discord_id: Optional[str] = Field(default=None, unique=True, nullable=True)
+    joined_at: datetime = Field(default_factory=_utcnow)
+    last_login: Optional[datetime] = Field(default=None)
+    is_active: bool = Field(default=True)
+
+
+class RoleHistory(SQLModel, table=True):
+    __tablename__ = "role_history"
+
+    id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
+    user_id: uuid.UUID = Field(foreign_key="users.id", nullable=False)
+    old_role: Optional[Role] = Field(
+        default=None,
+        sa_column=Column(
+            SAEnum(Role, name="role", create_constraint=False, native_enum=True),
+            nullable=True,
+        ),
+    )
+    new_role: Role = Field(
+        sa_column=Column(
+            SAEnum(Role, name="role", create_constraint=False, native_enum=True),
+            nullable=False,
+        )
+    )
+    changed_by: Optional[uuid.UUID] = Field(
+        default=None, foreign_key="users.id", nullable=True
+    )
+    changed_at: datetime = Field(default_factory=_utcnow)

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -1,0 +1,45 @@
+[project]
+name = "student-org-platform-server"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+    "fastapi>=0.110.0",
+    "uvicorn[standard]>=0.29.0",
+    "sqlmodel>=0.0.16",
+    "alembic>=1.13.0",
+    "psycopg2-binary>=2.9.9",
+    "supabase>=2.0.0",
+    "email-validator>=2.1.0",
+    "PyJWT>=2.8.0",
+    "cryptography>=42.0.0",
+    "python-dotenv>=1.0.0",
+    "alembic-postgresql-enum>=1.2.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.23.0",
+    "httpx>=0.27.0",
+    "ruff>=0.4.0",
+    "mypy>=1.9.0",
+]
+
+[tool.ruff]
+line-length = 88
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "I"]
+
+[tool.mypy]
+python_version = "3.11"
+strict = false
+ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+
+[tool.setuptools.packages.find]
+include = ["app*"]

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -1,0 +1,104 @@
+import os
+import uuid
+from collections.abc import AsyncGenerator, Generator
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import jwt
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlmodel import Session, SQLModel, create_engine
+
+# Must set env vars before importing app modules
+os.environ.setdefault("DATABASE_URL", "sqlite:///./test.db")
+os.environ.setdefault("TEST_DATABASE_URL", "sqlite:///./test.db")
+os.environ.setdefault("SUPABASE_URL", "https://test.supabase.co")
+os.environ.setdefault("SUPABASE_ANON_KEY", "test-anon-key")
+os.environ.setdefault("SUPABASE_SERVICE_ROLE_KEY", "test-service-role-key")
+os.environ.setdefault("SUPABASE_JWT_SECRET", "test-jwt-secret-32-chars-minimum!!")
+
+from app.database import get_session  # noqa: E402
+from app.main import app  # noqa: E402
+from app.users.models import Role, User  # noqa: E402, F401
+
+TEST_JWT_SECRET = os.environ["SUPABASE_JWT_SECRET"]
+
+TEST_DATABASE_URL = os.environ["TEST_DATABASE_URL"]
+test_engine = create_engine(
+    TEST_DATABASE_URL, connect_args={"check_same_thread": False}
+)
+
+
+@pytest.fixture(autouse=True)
+def setup_db() -> Generator:
+    SQLModel.metadata.create_all(test_engine)
+    yield
+    SQLModel.metadata.drop_all(test_engine)
+
+
+@pytest.fixture
+def db_session(setup_db: None) -> Generator[Session, None, None]:
+    with Session(test_engine) as session:
+        yield session
+
+
+@pytest.fixture
+def override_session(db_session: Session) -> Generator:
+    app.dependency_overrides[get_session] = lambda: db_session
+    yield
+    app.dependency_overrides.clear()
+
+
+@pytest_asyncio.fixture
+async def client(override_session: None) -> AsyncGenerator[AsyncClient, None]:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        yield c
+
+
+def make_supabase_mock(email: str, supabase_uid: str | None = None) -> MagicMock:
+    """Return a mock Supabase client for sign_up and sign_in_with_password."""
+    uid = supabase_uid or str(uuid.uuid4())
+
+    token = jwt.encode(
+        {
+            "sub": uid,
+            "email": email,
+            "aud": "authenticated",
+            "exp": int(datetime(2099, 1, 1, tzinfo=timezone.utc).timestamp()),
+        },
+        TEST_JWT_SECRET,
+        algorithm="HS256",
+    )
+
+    mock_user = MagicMock()
+    mock_user.id = uid
+
+    mock_session = MagicMock()
+    mock_session.access_token = token
+
+    mock_auth_resp = MagicMock()
+    mock_auth_resp.user = mock_user
+    mock_auth_resp.session = mock_session
+
+    mock_client = MagicMock()
+    mock_client.auth.sign_up.return_value = mock_auth_resp
+    mock_client.auth.sign_in_with_password.return_value = mock_auth_resp
+
+    return mock_client
+
+
+def make_supabase_admin_mock() -> MagicMock:
+    mock = MagicMock()
+    mock.auth.admin.delete_user.return_value = None
+    return mock
+
+
+SIGNUP_PAYLOAD = {
+    "email": "test@example.com",
+    "password": "password123",
+    "first_name": "Test",
+    "last_name": "User",
+}

--- a/server/tests/test_admin.py
+++ b/server/tests/test_admin.py
@@ -1,0 +1,198 @@
+"""Admin dashboard route tests.
+
+Auth users are created directly in the DB with a chosen role, and a matching
+JWT is minted with the TEST_JWT_SECRET (same approach the app uses to validate).
+Supabase auth deletion is mocked.
+"""
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import jwt
+import pytest
+from httpx import AsyncClient
+from sqlmodel import Session, select
+
+from app.admin.models import AdminAuditLog
+from app.users.models import Role, User
+from tests.conftest import TEST_JWT_SECRET
+
+
+def _make_user(session: Session, role: Role, email: str | None = None) -> User:
+    uid = str(uuid.uuid4())
+    user = User(
+        supabase_id=uid,
+        email=email or f"{uid}@example.com",
+        first_name="Test",
+        last_name="User",
+        role=role,
+    )
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    return user
+
+
+def _token(user: User) -> str:
+    return jwt.encode(
+        {
+            "sub": user.supabase_id,
+            "email": user.email,
+            "aud": "authenticated",
+            "exp": int(datetime(2099, 1, 1, tzinfo=timezone.utc).timestamp()),
+        },
+        TEST_JWT_SECRET,
+        algorithm="HS256",
+    )
+
+
+def _auth(user: User) -> dict[str, str]:
+    return {"Authorization": f"Bearer {_token(user)}"}
+
+
+@pytest.mark.asyncio
+async def test_dev_cannot_list_users(
+    client: AsyncClient, db_session: Session
+) -> None:
+    dev = _make_user(db_session, Role.DEV)
+    resp = await client.get("/api/admin/users", headers=_auth(dev))
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_admin_can_list_users(
+    client: AsyncClient, db_session: Session
+) -> None:
+    admin = _make_user(db_session, Role.ADMIN)
+    resp = await client.get("/api/admin/users", headers=_auth(admin))
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] >= 1
+    assert isinstance(body["rows"], list)
+
+
+@pytest.mark.asyncio
+async def test_resources_hide_users_from_dev(
+    client: AsyncClient, db_session: Session
+) -> None:
+    dev = _make_user(db_session, Role.DEV)
+    resp = await client.get("/api/admin/resources", headers=_auth(dev))
+    assert resp.status_code == 200
+    names = {r["name"] for r in resp.json()["resources"]}
+    assert "users" not in names
+    assert "role_history" not in names
+
+
+@pytest.mark.asyncio
+async def test_resources_show_users_to_admin(
+    client: AsyncClient, db_session: Session
+) -> None:
+    admin = _make_user(db_session, Role.ADMIN)
+    resp = await client.get("/api/admin/resources", headers=_auth(admin))
+    names = {r["name"] for r in resp.json()["resources"]}
+    assert "users" in names
+
+
+@pytest.mark.asyncio
+async def test_admin_delete_user(client: AsyncClient, db_session: Session) -> None:
+    admin = _make_user(db_session, Role.ADMIN)
+    # second admin so the target is deletable and admin isn't the last one
+    _make_user(db_session, Role.ADMIN)
+    victim = _make_user(db_session, Role.MEMBER)
+    victim_id = str(victim.id)
+
+    sb_admin = MagicMock()
+    with patch("app.admin.service.get_supabase_admin", return_value=sb_admin):
+        resp = await client.delete(
+            f"/api/admin/users/{victim_id}", headers=_auth(admin)
+        )
+
+    assert resp.status_code == 204
+    sb_admin.auth.admin.delete_user.assert_called_once()
+    assert db_session.get(User, victim.id) is None
+
+    audit = db_session.exec(
+        select(AdminAuditLog).where(AdminAuditLog.target_id == victim_id)
+    ).first()
+    assert audit is not None
+
+
+@pytest.mark.asyncio
+async def test_cannot_delete_self(client: AsyncClient, db_session: Session) -> None:
+    admin = _make_user(db_session, Role.ADMIN)
+    _make_user(db_session, Role.ADMIN)  # not the last admin
+    resp = await client.delete(
+        f"/api/admin/users/{admin.id}", headers=_auth(admin)
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_cannot_deactivate_last_active_admin(
+    client: AsyncClient, db_session: Session
+) -> None:
+    # Actor is an admin (allowed by role gate) but is itself inactive, so the
+    # target is the only remaining active admin and must be protected.
+    actor = _make_user(db_session, Role.ADMIN)
+    actor.is_active = False
+    db_session.add(actor)
+    last_active_admin = _make_user(db_session, Role.ADMIN)
+    db_session.commit()
+
+    resp = await client.post(
+        f"/api/admin/users/{last_active_admin.id}/deactivate",
+        headers=_auth(actor),
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_deactivate_and_reactivate_user(
+    client: AsyncClient, db_session: Session
+) -> None:
+    admin = _make_user(db_session, Role.ADMIN)
+    victim = _make_user(db_session, Role.MEMBER)
+
+    resp = await client.post(
+        f"/api/admin/users/{victim.id}/deactivate", headers=_auth(admin)
+    )
+    assert resp.status_code == 200
+    assert resp.json()["row"]["is_active"] is False
+
+    resp = await client.post(
+        f"/api/admin/users/{victim.id}/reactivate", headers=_auth(admin)
+    )
+    assert resp.status_code == 200
+    assert resp.json()["row"]["is_active"] is True
+
+
+@pytest.mark.asyncio
+async def test_dev_blocked_from_delete_users(
+    client: AsyncClient, db_session: Session
+) -> None:
+    dev = _make_user(db_session, Role.DEV)
+    victim = _make_user(db_session, Role.MEMBER)
+    resp = await client.delete(
+        f"/api/admin/users/{victim.id}", headers=_auth(dev)
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_unknown_resource_404(
+    client: AsyncClient, db_session: Session
+) -> None:
+    admin = _make_user(db_session, Role.ADMIN)
+    resp = await client.get("/api/admin/nope", headers=_auth(admin))
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_audit_admin_only(client: AsyncClient, db_session: Session) -> None:
+    dev = _make_user(db_session, Role.DEV)
+    admin = _make_user(db_session, Role.ADMIN)
+
+    assert (await client.get("/api/admin/audit", headers=_auth(dev))).status_code == 403
+    assert (
+        await client.get("/api/admin/audit", headers=_auth(admin))
+    ).status_code == 200

--- a/server/tests/test_auth.py
+++ b/server/tests/test_auth.py
@@ -1,0 +1,145 @@
+"""Auth route integration tests.
+
+Each test is independent — no shared state. Supabase calls are mocked; JWT
+validation uses the TEST_JWT_SECRET set in conftest.py.
+"""
+from unittest.mock import patch
+
+import pytest
+from httpx import AsyncClient
+from sqlmodel import Session, select
+
+from app.auth.dependencies import require_role
+from app.main import app
+from app.users.models import Role, User
+from tests.conftest import SIGNUP_PAYLOAD, make_supabase_admin_mock, make_supabase_mock
+
+
+@pytest.mark.asyncio
+async def test_signup_creates_member(client: AsyncClient, db_session: Session) -> None:
+    """POST /signup returns 201, role=MEMBER, and the DB row is correct."""
+    sb_mock = make_supabase_mock(SIGNUP_PAYLOAD["email"])
+    sb_admin_mock = make_supabase_admin_mock()
+
+    with (
+        patch("app.auth.service.get_supabase", return_value=sb_mock),
+        patch("app.auth.service.get_supabase_admin", return_value=sb_admin_mock),
+    ):
+        resp = await client.post("/api/auth/signup", json=SIGNUP_PAYLOAD)
+
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["role"] == "MEMBER"
+    assert body["email"] == SIGNUP_PAYLOAD["email"]
+    assert body["first_name"] == SIGNUP_PAYLOAD["first_name"]
+
+    user = db_session.exec(
+        select(User).where(User.email == SIGNUP_PAYLOAD["email"])
+    ).first()
+    assert user is not None
+    assert user.role == Role.MEMBER
+    assert user.supabase_id is not None
+
+
+@pytest.mark.asyncio
+async def test_login_returns_token(client: AsyncClient) -> None:
+    """POST /login returns 200 with a non-empty access_token."""
+    sb_mock = make_supabase_mock(SIGNUP_PAYLOAD["email"])
+    sb_admin_mock = make_supabase_admin_mock()
+
+    with (
+        patch("app.auth.service.get_supabase", return_value=sb_mock),
+        patch("app.auth.service.get_supabase_admin", return_value=sb_admin_mock),
+    ):
+        await client.post("/api/auth/signup", json=SIGNUP_PAYLOAD)
+        resp = await client.post(
+            "/api/auth/login",
+            json={"email": SIGNUP_PAYLOAD["email"], "password": SIGNUP_PAYLOAD["password"]},  # noqa: E501
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "access_token" in body
+    assert isinstance(body["access_token"], str)
+    assert len(body["access_token"]) > 0
+
+
+@pytest.mark.asyncio
+async def test_me_with_valid_token(client: AsyncClient) -> None:
+    """GET /me with a valid token returns correct user data."""
+    sb_mock = make_supabase_mock(SIGNUP_PAYLOAD["email"])
+    sb_admin_mock = make_supabase_admin_mock()
+
+    with (
+        patch("app.auth.service.get_supabase", return_value=sb_mock),
+        patch("app.auth.service.get_supabase_admin", return_value=sb_admin_mock),
+    ):
+        await client.post("/api/auth/signup", json=SIGNUP_PAYLOAD)
+        login_resp = await client.post(
+            "/api/auth/login",
+            json={"email": SIGNUP_PAYLOAD["email"], "password": SIGNUP_PAYLOAD["password"]},  # noqa: E501
+        )
+
+    token = login_resp.json()["access_token"]
+    resp = await client.get(
+        "/api/auth/me", headers={"Authorization": f"Bearer {token}"}
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["email"] == SIGNUP_PAYLOAD["email"]
+    assert body["role"] == "MEMBER"
+    assert "id" in body
+    assert "first_name" in body
+    assert "last_name" in body
+    assert "joined_at" in body
+
+
+@pytest.mark.asyncio
+async def test_me_without_token(client: AsyncClient) -> None:
+    """GET /me with no Authorization header returns 401."""
+    resp = await client.get("/api/auth/me")
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_me_with_invalid_token(client: AsyncClient) -> None:
+    """GET /me with a garbage token returns 401."""
+    resp = await client.get(
+        "/api/auth/me", headers={"Authorization": "Bearer invalidtoken"}
+    )
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_require_role_blocks_wrong_role(client: AsyncClient) -> None:
+    """A MEMBER token is rejected by a route protected with require_role(ADMIN)."""
+    from fastapi import APIRouter, Depends
+
+    # Register a temporary ADMIN-only route for this test
+    test_router = APIRouter()
+
+    @test_router.get("/test-admin-only")
+    def admin_only(user: User = Depends(require_role(Role.ADMIN))) -> dict:
+        return {"ok": True}
+
+    app.include_router(test_router)
+
+    sb_mock = make_supabase_mock(SIGNUP_PAYLOAD["email"])
+    sb_admin_mock = make_supabase_admin_mock()
+
+    with (
+        patch("app.auth.service.get_supabase", return_value=sb_mock),
+        patch("app.auth.service.get_supabase_admin", return_value=sb_admin_mock),
+    ):
+        await client.post("/api/auth/signup", json=SIGNUP_PAYLOAD)
+        login_resp = await client.post(
+            "/api/auth/login",
+            json={"email": SIGNUP_PAYLOAD["email"], "password": SIGNUP_PAYLOAD["password"]},  # noqa: E501
+        )
+
+    token = login_resp.json()["access_token"]
+    resp = await client.get(
+        "/test-admin-only", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert resp.status_code == 403


### PR DESCRIPTION
## Summary
Adds the student org platform as two new top-level folders in the repo:

- **`server/`** — FastAPI + SQLModel + Alembic backend
  - Supabase Auth integration (`/api/auth` signup / login / me)
  - Role-based access control (`MEMBER < DEV < ADMIN`) via `auth/dependencies.py`
  - Admin CRUD + audit log (`/api/admin`)
  - Alembic migrations and pytest suite
  - `_template/` reference module for building new features
- **`dashboard/`** — React 19 + Vite + Tailwind admin UI (auth flow, resource tables, audit view)

### Notes
- `server/.env.example` and `dashboard/.env.example` document all required env vars (Supabase, Notion, CORS). No secrets committed.
- Root `.gitignore` extended with a backend (Python) section; existing frontend ignores untouched.
- The Discord `bot/` is **not** included (not yet implemented).
- Build artifacts (node_modules, dist, .venv, caches, *.db, tsbuildinfo) are excluded.

## Test plan
- [ ] Backend: `cd server && cp .env.example .env` (fill Supabase test-project values), `pip install -e ".[dev]"`, `alembic upgrade head`, `pytest`, `uvicorn app.main:app --reload`
- [ ] Frontend: `cd dashboard && cp .env.example .env` (fill values), `npm install`, `npm run dev`
- [ ] Confirm the added folders do not interfere with the existing landing-site build

Made with [Cursor](https://cursor.com)